### PR TITLE
Fix 'OrNull = true' to allow null path

### DIFF
--- a/godot/MyGui.cs
+++ b/godot/MyGui.cs
@@ -6,6 +6,8 @@ public partial class MyGui : VBoxContainer
 {
 	[OnReadyPath(nameof(OptionalButton), OrNull = true)] public Button OptionalButton { get; set; }
 
+	[OnReadyPath(OrNull = true)] public Button FullyOptionalButton { get; set; }
+
 	[OnReadyPath("LineEdit")] public LineEdit AddLineBox { get; set; }
 
 	[OnReady]

--- a/src/GodotOnReady.Generator/Additions/OnReadyPathAddition.cs
+++ b/src/GodotOnReady.Generator/Additions/OnReadyPathAddition.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using System;
 
 namespace GodotOnReady.Generator.Additions
 {
@@ -54,6 +55,22 @@ namespace GodotOnReady.Generator.Additions
 		public override bool WritesOnReadyStatements => true;
 
 		public override void WriteOnReadyStatement(SourceStringBuilder g)
+		{
+			if (MemberType is null) return;
+			if (MemberName is null) return;
+
+			if (OrNull)
+			{
+				g.Line("if (", MemberPathNameOrDefault, " != null)");
+				g.BlockBrace(() => WriteGetNodeLine(g));
+			}
+			else
+			{
+				WriteGetNodeLine(g);
+			}
+		}
+
+		private void WriteGetNodeLine(SourceStringBuilder g)
 		{
 			if (MemberType is null) return;
 			if (MemberName is null) return;


### PR DESCRIPTION
Fixes this:

```cs
[OnReadyPath(OrNull = true)] public Button FullyOptionalButton { get; set; }
```

to generate this code with the `if`:

```cs
if (FullyOptionalButtonPath != null)
{
	FullyOptionalButton = GetNodeOrNull<global::Godot.Button>(FullyOptionalButtonPath);
}
```

Right now it doesn't have the `if`. If nobody specifies the path in the editor, the code needs to avoid calling `GetNodeOrNull` or we'll crash.