### PR TITLE
Clean up

### DIFF
--- a/src/GodotOnReady.Generator/Additions/OnReadyAddition.cs
+++ b/src/GodotOnReady.Generator/Additions/OnReadyAddition.cs
@@ -4,10 +4,16 @@ namespace GodotOnReady.Generator.Additions
 {
 	public class OnReadyAddition : PartialClassAddition
 	{
-		public IMethodSymbol? Method { get; set; }
+		public IMethodSymbol Method { get; }
 
-		public OnReadyAddition(AttributeData attribute)
+		public OnReadyAddition(
+			IMethodSymbol method,
+			AttributeData attribute,
+			INamedTypeSymbol @class)
+			: base(@class)
 		{
+			Method = method;
+
 			foreach (var namedArg in attribute.NamedArguments)
 			{
 				if (namedArg.Key == "Order" && namedArg.Value.Value is int i)
@@ -21,8 +27,6 @@ namespace GodotOnReady.Generator.Additions
 
 		public override void WriteOnReadyStatement(SourceStringBuilder g)
 		{
-			if (Method is null) return;
-
 			g.Line(Method.Name, "();");
 		}
 	}

--- a/src/GodotOnReady.Generator/Additions/OnReadyGetAddition.cs
+++ b/src/GodotOnReady.Generator/Additions/OnReadyGetAddition.cs
@@ -1,37 +1,33 @@
-﻿using GodotOnReady.Generator.Util;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using System;
-
-namespace GodotOnReady.Generator.Additions
+﻿namespace GodotOnReady.Generator.Additions
 {
-	public class OnReadyGetAddition : PartialClassAddition
+	public abstract class OnReadyGetAddition : PartialClassAddition
 	{
-		public string MemberType { get; set; }
-		public string MemberName { get; set; }
-		public string SuffixlessExportPropertyName { get; set; }
+		public MemberSymbol Member { get; }
 
-		public GettableBaseType BaseType { get; }
+		/// <summary>
+		/// The name of the export property, without any suffix that differentiates it from the main
+		/// member (such as Resource or Path).
+		/// </summary>
+		public string SuffixlessExportPropertyName { get; }
 
-		public string? Default { get; set; }
+		public string? Default { get; }
+		public bool OrNull { get; }
+		public bool Private { get; }
 
-		public bool OrNull { get; set; }
-
-		public bool Private { get; set; }
-
-		private OnReadyGetAddition(
-			AttributeData attribute,
-			ITypeSymbol memberTypeSymbol,
-			string memberName,
-			string suffixlessExportPropertyName,
-			GettableBaseType baseType)
+		public OnReadyGetAddition(MemberAttributeSite memberSite)
+			: base(memberSite.AttributeSite.Class)
 		{
-			MemberType = memberTypeSymbol.ToFullDisplayString();
-			MemberName = memberName;
-			SuffixlessExportPropertyName = suffixlessExportPropertyName;
-			BaseType = baseType;
+			Member = memberSite.Member;
 
-			foreach (var constructorArg in attribute.ConstructorArguments)
+			// Handle field name convention: _ prefix with lowercase name.
+			string pathName = Member.Name.TrimStart('_');
+			pathName =
+				pathName[0].ToString().ToUpperInvariant() +
+				pathName.Substring(1);
+
+			SuffixlessExportPropertyName = pathName;
+
+			foreach (var constructorArg in memberSite.AttributeSite.Attribute.ConstructorArguments)
 			{
 				if (constructorArg.Value is string @default)
 				{
@@ -39,167 +35,21 @@ namespace GodotOnReady.Generator.Additions
 				}
 			}
 
-			foreach (var namedArg in attribute.NamedArguments)
+			foreach (var namedArg in memberSite.AttributeSite.Attribute.NamedArguments)
 			{
-				if (namedArg.Key == "Default" && namedArg.Value.Value is string @default)
+				switch (namedArg.Key)
 				{
-					Default = @default;
+					case "Default" when namedArg.Value.Value is string s:
+						Default = s;
+						break;
+					case "OrNull" when namedArg.Value.Value is bool b:
+						OrNull = b;
+						break;
+					case "Private" when namedArg.Value.Value is bool b:
+						Private = b;
+						break;
 				}
-				else if (namedArg.Key == "OrNull" && namedArg.Value.Value is bool orNull)
-				{
-					OrNull = orNull;
-				}
-				else if (namedArg.Key == "Private" && namedArg.Value.Value is bool @private)
-				{
-					Private = @private;
-				}
 			}
 		}
-
-		public OnReadyGetAddition(
-			AttributeData attribute,
-			IPropertySymbol propertySymbol,
-			GettableBaseType baseType)
-			: this(
-				attribute,
-				propertySymbol.Type,
-				propertySymbol.Name,
-				propertySymbol.Name, baseType) { }
-
-		public OnReadyGetAddition(
-			AttributeData attribute,
-			IFieldSymbol fieldSymbol,
-			GettableBaseType baseType)
-			: this(
-				attribute,
-				fieldSymbol.Type,
-				fieldSymbol.Name,
-				GetSuffixlessExportPropertyNameForMemberName(fieldSymbol.Name), baseType) { }
-
-		public override void WriteDeclaration(SourceStringBuilder g)
-		{
-			string export = Private ? "" : "[Export] ";
-
-			switch (BaseType)
-			{
-				case GettableBaseType.Resource:
-					g.Line(export, "public ", MemberType, " ", ExportPropertyName);
-					g.BlockBrace(() =>
-					{
-						g.Line("get => ", MemberName, ";");
-						g.Line("set { _hasBeenSet", MemberName, " = true; ", MemberName, " = value; }");
-					});
-
-					g.Line("private bool _hasBeenSet", MemberName, ";");
-
-					break;
-
-				case GettableBaseType.Node:
-					g.Line(export, "public NodePath ", ExportPropertyName, " { get; set; }");
-
-					if (Default is { Length: >0 })
-					{
-						g.BlockTab(() =>
-						{
-							g.Line("= ", SyntaxFactory.Literal(Default).ToString(), ";");
-						});
-					}
-
-					break;
-			}
-		}
-
-		public override bool WritesConstructorStatements => BaseType == GettableBaseType.Resource;
-
-		public override void WriteConstructorStatement(SourceStringBuilder g)
-		{
-			switch (BaseType)
-			{
-				case GettableBaseType.Resource:
-					g.Line("if (Engine.EditorHint)");
-					g.BlockBrace(() =>
-					{
-						WriteAssignment(g);
-					});
-					break;
-			}
-		}
-
-		public override bool WritesOnReadyStatements => true;
-
-		public override void WriteOnReadyStatement(SourceStringBuilder g)
-		{
-			switch (BaseType)
-			{
-				case GettableBaseType.Resource:
-					if (Default is { Length: >0 })
-					{
-						g.Line("if (!_hasBeenSet", MemberName, ")");
-						g.BlockBrace(() =>
-						{
-							WriteAssignment(g);
-						});
-					}
-
-					if (!OrNull)
-					{
-						g.Line("if (", MemberName, " == null) " +
-							"throw new NullReferenceException($\"",
-							MemberName, " is null, but OnReadyLoad not OrNull=true. (Default = '",
-							Default ?? "null", "') ",
-							"(Node = '{Name}' '{this}')\");");
-					}
-
-					break;
-
-				case GettableBaseType.Node:
-					if (OrNull)
-					{
-						g.Line("if (", ExportPropertyName, " != null)");
-						g.BlockBrace(() => WriteGetNodeLine(g));
-					}
-					else
-					{
-						WriteGetNodeLine(g);
-					}
-
-					break;
-			}
-		}
-
-		private void WriteGetNodeLine(SourceStringBuilder g)
-		{
-			g.Line(MemberName, " = GetNode" +
-				(OrNull ? "OrNull" : "") +
-				"<", MemberType, ">" +
-				"(", ExportPropertyName, ");");
-		}
-
-		private void WriteAssignment(SourceStringBuilder g)
-		{
-			if (Default is not { Length: >0 }) return;
-
-			g.Line(MemberName, " = GD.Load",
-				"<", MemberType, ">",
-				"(", SyntaxFactory.Literal(Default).ToString(), ");");
-		}
-
-		private static string GetSuffixlessExportPropertyNameForMemberName(string fieldName)
-		{
-			// Handle field name convention: _ prefix with lowercase name.
-			string pathName = fieldName.TrimStart('_');
-			pathName =
-				pathName[0].ToString().ToUpperInvariant() +
-				pathName.Substring(1);
-
-			return pathName;
-		}
-
-		private string ExportPropertyName => SuffixlessExportPropertyName + BaseType switch
-		{
-			GettableBaseType.Resource => "Resource",
-			GettableBaseType.Node => "Path",
-			_ => throw new ArgumentOutOfRangeException()
-		};
 	}
 }

--- a/src/GodotOnReady.Generator/Additions/OnReadyGetNodeAddition.cs
+++ b/src/GodotOnReady.Generator/Additions/OnReadyGetNodeAddition.cs
@@ -1,0 +1,52 @@
+﻿using GodotOnReady.Generator.Util;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace GodotOnReady.Generator.Additions
+{
+	public class OnReadyGetNodeAddition : OnReadyGetAddition
+	{
+		public OnReadyGetNodeAddition(MemberAttributeSite site) : base(site) { }
+
+		public override void WriteDeclaration(SourceStringBuilder g)
+		{
+			string export = Private ? "" : "[Export] ";
+
+			g.Line();
+			g.Line(export, "public NodePath ", ExportPropertyName, " { get; set; }");
+
+			if (Default is { Length: >0 })
+			{
+				g.BlockTab(() =>
+				{
+					g.Line("= ", SyntaxFactory.Literal(Default).ToString(), ";");
+				});
+			}
+		}
+
+		public override bool WritesOnReadyStatements => true;
+
+		public override void WriteOnReadyStatement(SourceStringBuilder g)
+		{
+			if (OrNull)
+			{
+				g.Line("if (", ExportPropertyName, " != null)");
+				g.BlockBrace(() => WriteGetNodeLine(g));
+				g.Line();
+			}
+			else
+			{
+				WriteGetNodeLine(g);
+			}
+		}
+
+		private void WriteGetNodeLine(SourceStringBuilder g)
+		{
+			g.Line(Member.Name, " = GetNode" +
+				(OrNull ? "OrNull" : "") +
+				"<", Member.Type.ToFullDisplayString(), ">" +
+				"(", ExportPropertyName, ");");
+		}
+
+		protected virtual string ExportPropertyName => SuffixlessExportPropertyName + "Path";
+	}
+}

--- a/src/GodotOnReady.Generator/Additions/OnReadyGetResourceAddition.cs
+++ b/src/GodotOnReady.Generator/Additions/OnReadyGetResourceAddition.cs
@@ -1,0 +1,71 @@
+﻿using GodotOnReady.Generator.Util;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace GodotOnReady.Generator.Additions
+{
+	public class OnReadyGetResourceAddition : OnReadyGetAddition
+	{
+		public OnReadyGetResourceAddition(MemberAttributeSite site) : base(site) { }
+
+		private bool IsGeneratingAssignment => Default is { Length: >0 };
+
+		public override void WriteDeclaration(SourceStringBuilder g)
+		{
+			string export = Private ? "" : "[Export] ";
+
+			g.Line(export, "public ", Member.Type.ToFullDisplayString(), " ", ExportPropertyName);
+			g.BlockBrace(() =>
+			{
+				g.Line("get => ", Member.Name, ";");
+				g.Line("set { _hasBeenSet", Member.Name, " = true; ", Member.Name, " = value; }");
+			});
+
+			g.Line("private bool _hasBeenSet", Member.Name, ";");
+		}
+
+		public override bool WritesConstructorStatements => IsGeneratingAssignment;
+
+		public override void WriteConstructorStatement(SourceStringBuilder g)
+		{
+			if (!IsGeneratingAssignment) return;
+
+			g.Line("if (Engine.EditorHint)");
+			g.BlockBrace(() =>
+			{
+				WriteAssignment(g);
+			});
+		}
+
+		public override bool WritesOnReadyStatements => true;
+
+		public override void WriteOnReadyStatement(SourceStringBuilder g)
+		{
+			if (IsGeneratingAssignment)
+			{
+				g.Line("if (!_hasBeenSet", Member.Name, ")");
+				g.BlockBrace(() =>
+				{
+					WriteAssignment(g);
+				});
+			}
+
+			if (!OrNull)
+			{
+				g.Line("if (", Member.Name, " == null) " +
+					"throw new NullReferenceException($\"",
+					Member.Name, " is null, but OnReadyLoad not OrNull=true. (Default = '",
+					Default ?? "null", "') ",
+					"(Node = '{Name}' '{this}')\");");
+			}
+		}
+
+		private void WriteAssignment(SourceStringBuilder g)
+		{
+			g.Line(Member.Name, " = GD.Load",
+				"<", Member.Type.ToFullDisplayString(), ">",
+				"(", SyntaxFactory.Literal(Default ?? "").ToString(), ");");
+		}
+
+		protected virtual string ExportPropertyName => SuffixlessExportPropertyName + "Resource";
+	}
+}

--- a/src/GodotOnReady.Generator/Additions/PartialClassAddition.cs
+++ b/src/GodotOnReady.Generator/Additions/PartialClassAddition.cs
@@ -4,10 +4,14 @@ namespace GodotOnReady.Generator.Additions
 {
 	public abstract class PartialClassAddition
 	{
-		public INamedTypeSymbol? Class { get; set; }
+		protected PartialClassAddition(INamedTypeSymbol @class)
+		{
+			Class = @class;
+		}
+
+		public INamedTypeSymbol Class { get; }
 
 		public int Order { get; set; }
-
 
 		public virtual void WriteDeclaration(SourceStringBuilder g) { }
 

--- a/src/GodotOnReady.Generator/MemberSymbol.cs
+++ b/src/GodotOnReady.Generator/MemberSymbol.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace GodotOnReady.Generator
+{
+	public record MemberSymbol(ITypeSymbol Type, string Name, ISymbol Symbol)
+	{
+		public static MemberSymbol Create(IPropertySymbol member) => new(
+			member.Type, member.Name, member);
+
+		public static MemberSymbol Create(IFieldSymbol member) => new(
+			member.Type, member.Name, member);
+	}
+}

--- a/src/GodotOnReady.Generator/SourceStringBuilder.cs
+++ b/src/GodotOnReady.Generator/SourceStringBuilder.cs
@@ -10,11 +10,14 @@ namespace GodotOnReady.Generator
 
 		public void Line(params string[] parts)
 		{
-			_sourceBuilder.Append(_indentPrefix);
-
-			foreach (var s in parts)
+			if (parts.Length != 0)
 			{
-				_sourceBuilder.Append(s);
+				_sourceBuilder.Append(_indentPrefix);
+
+				foreach (var s in parts)
+				{
+					_sourceBuilder.Append(s);
+				}
 			}
 
 			_sourceBuilder.AppendLine();

--- a/src/GodotOnReady.Generator/Util/IsExternalInit.cs
+++ b/src/GodotOnReady.Generator/Util/IsExternalInit.cs
@@ -1,0 +1,5 @@
+﻿// ReSharper disable CheckNamespace
+namespace System.Runtime.CompilerServices
+{
+	public class IsExternalInit { }
+}


### PR DESCRIPTION
* Factor out more Addition classes.
* Transfer some data using records to avoid constructor bloat.
* Add "MemberSymbol" abstraction over IPropertySymbol and IFieldSymbol.
* Fix trailing whitespace.
* Remove unnecessary nullable properties (use constructors/records instead).