### PR TITLE
Improve null checking and exception message

### DIFF
--- a/godot/MyGui.cs
+++ b/godot/MyGui.cs
@@ -11,6 +11,12 @@ public partial class MyGui : VBoxContainer
 
 	[OnReadyGet("LineEdit")] public LineEdit AddLineBox { get; set; }
 
+	// [OnReadyGet] private Button _nullNode;
+	// [OnReadyGet] private Texture _nullResource;
+
+	// [OnReadyGet("a/b/c")] private Button _notFoundNode;
+	// [OnReadyGet("a/b/d")] private Texture _notFoundResource;
+
 	[OnReady]
 	public void InitializeInput()
 	{

--- a/src/GodotOnReady.Generator/Additions/OnReadyGetAddition.cs
+++ b/src/GodotOnReady.Generator/Additions/OnReadyGetAddition.cs
@@ -51,5 +51,20 @@
 				}
 			}
 		}
+
+		protected void WriteMemberNullCheck(SourceStringBuilder g, string exportMemberName)
+		{
+			g.Line("if (", Member.Name, " == null)");
+			g.BlockBrace(() =>
+			{
+				g.Line(
+					"throw new NullReferenceException($\"",
+					"'{((Resource)GetScript()).ResourcePath}' member '",
+					Member.Name,
+					"' is unexpectedly null in '{GetPath()}', '{this}'. Ensure '",
+					exportMemberName,
+					"' is set correctly, or set [OnReadyGet(OrNull = true)] to allow null.\");");
+			});
+		}
 	}
 }

--- a/src/GodotOnReady.Generator/Additions/OnReadyGetNodeAddition.cs
+++ b/src/GodotOnReady.Generator/Additions/OnReadyGetNodeAddition.cs
@@ -27,15 +27,13 @@ namespace GodotOnReady.Generator.Additions
 		public override Action<SourceStringBuilder>? OnReadyStatementWriter => g =>
 		{
 			g.Line();
-			if (OrNull)
+
+			g.Line("if (", ExportPropertyName, " != null)");
+			g.BlockBrace(() => WriteGetNodeLine(g));
+
+			if (!OrNull)
 			{
-				g.Line("if (", ExportPropertyName, " != null)");
-				g.BlockBrace(() => WriteGetNodeLine(g));
-				g.Line();
-			}
-			else
-			{
-				WriteGetNodeLine(g);
+				WriteMemberNullCheck(g, ExportPropertyName);
 			}
 		};
 

--- a/src/GodotOnReady.Generator/Additions/OnReadyGetResourceAddition.cs
+++ b/src/GodotOnReady.Generator/Additions/OnReadyGetResourceAddition.cs
@@ -54,16 +54,7 @@ namespace GodotOnReady.Generator.Additions
 
 					if (!OrNull)
 					{
-						g.Line("if (", Member.Name, " == null)");
-						g.BlockBrace(() =>
-						{
-							g.Line(
-								"throw new NullReferenceException($\"",
-								Member.Name,
-								" is null, but OnReadyLoad not OrNull=true. (Default = '",
-								Default ?? "null", "') ",
-								"(Node = '{Name}' '{this}')\");");
-						});
+						WriteMemberNullCheck(g, ExportPropertyName);
 					}
 				}
 				: null;


### PR DESCRIPTION
Fixes https://github.com/31/GodotOnReady/issues/15: now unless `OrNull = true`, the generated Ready method generates a thorough message including member name, node path, script resource path, exported member name, and node `ToString`. This works for resources and nodes.

Fixes https://github.com/31/GodotOnReady/issues/16: now check the result of `GetNode` for null. Fixes an assumption that `GetNode` will throw if the node path points somewhere that doesn't exist: it actually returns null. This also means we'll get a nice exception with lots of detail rather than the generic one that Godot throws.