### PR TITLE
Change defaults: private by default if a path is given

### DIFF
--- a/docs/GenerateDataSelectorEnum.md
+++ b/docs/GenerateDataSelectorEnum.md
@@ -1,0 +1,102 @@
+### `[GenerateDataSelectorEnum]`
+
+This utility allows you to concisely add some custom data to each member of an
+`enum`.
+
+An `enum` works nicely to show a choice in the Godot editor while authoring a
+scene:
+
+```cs
+public enum SleepPreference { Bed, Floor, Microgravity }
+
+public partial class Person : Node2D
+{
+  [Export] public SleepPreference Pref { get; set; }
+  [OnReady] private void PrintPref()
+  {
+    GD.Print(Pref);
+  }
+}
+```
+
+Let's add a `float Comfort` factor to each enum member. Here's a way that uses
+`switch` and provides a convenient `.GetData` method that can be called on the
+enum:
+
+```cs
+public enum SleepPreference { Bed, Floor, Microgravity }
+
+public class SleepPreferenceData
+{
+  private static readonly SleepPreferenceData
+    Bed = new SleepPreferenceData { Comfort = 1f },
+    Floor = new SleepPreferenceData { Comfort = 0.6f },
+    Microgravity = new SleepPreferenceData { Comfort = 0.6f };
+
+  public static SleepPreferenceData Get(SleepPreference p)
+  {
+    switch(p)
+    {
+      case SleepPreference.Bed: return Bed;
+      case SleepPreference.Floor: return Floor;
+      case SleepPreference.Microgravity: return Microgravity;
+    }
+    throw new ArgumentOutOfRangeException("key");
+  }
+
+  public float Comfort { get; set; }
+}
+
+public static class SleepPreferenceExtensions {
+  public static SleepPreferenceData GetData(this SleepPreference p) => SleepPreferenceData.Get(p);
+}
+```
+
+Usage:
+
+```cs
+public partial class Person : Node2D
+{
+  [Export] public SleepPreference Pref { get; set; }
+
+  [OnReady] private void PrintPref()
+  {
+    GD.Print(Pref);
+    GD.Print(Pref.GetData().Comfort);
+  }
+}
+```
+
+That's fine, but every value name in `SleepPreference` is written four times, in
+a few separate sections of the code. To add a new enum value, every place needs
+to be updated in sync.
+
+> You can shrink this down from three to two times if you use a Dictionary
+> instead of a switch. Down to only one time, if you use an attribute on each
+> enum member (although attributes limit the data types you can set). There are
+> theoretically some performance differences, with `switch` *maybe* being the
+> best, but these differences probably aren't important for most usage. The
+> source generator uses `switch` rather than a dictionary somewhat arbitrarily.
+
+Instead, use `GenerateDataSelectorEnum` to generate all of that code based on
+the data object field names:
+
+```cs
+[GenerateDataSelectorEnum("SleepPreference")]
+public partial class SleepPreferenceData
+{
+  private static readonly SleepPreferenceData
+    Bed = new SleepPreferenceData { Comfort = 1f },
+    Floor = new SleepPreferenceData { Comfort = 0.6f },
+    Microgravity = new SleepPreferenceData { Comfort = 0.6f };
+
+  public float Comfort { get; set; }
+}
+```
+
+To add a new enum value, just add another field to `SleepPreferenceData`.
+
+If you use C# 9.0, you can also use *target-typed new* to shrink this:  
+`Bed = new SleepPreferenceData { Comfort = 1f }`  
+down to this:  
+`Bed = new() { Comfort = 1f }`.

--- a/godot/Demo.cs
+++ b/godot/Demo.cs
@@ -17,13 +17,13 @@ public partial class Demo : Node
 
 	[OnReadyGet("Example")] public Node _exampleDefault;
 	[OnReadyGet("Example", OrNull = true)] public Node _exampleDefaultOrNullTrue;
-	[OnReadyGet("Example", Private = true)] public Node _exampleDefaultPrivateTrue;
-	[OnReadyGet("Example", OrNull = true, Private = true)] public Node _exampleDefaultOrNullPrivateTrue;
+	[OnReadyGet("Example", Export = true)] public Node _exampleDefaultExportTrue;
+	[OnReadyGet("Example", OrNull = true, Export = true)] public Node _exampleDefaultOrNullExportTrue;
 
 	[OnReadyGet("res://tex.png")] public PackedScene _exampleDefaultPackedScene;
 	[OnReadyGet("res://tex.png", OrNull = true)] public PackedScene _exampleDefaultOrNullTruePackedScene;
-	[OnReadyGet("res://tex.png", Private = true)] public PackedScene _exampleDefaultPrivateTruePackedScene;
-	[OnReadyGet("res://tex.png", OrNull = true, Private = true)] public PackedScene _exampleDefaultOrNullPrivateTruePackedScene;
+	[OnReadyGet("res://tex.png", Export = true)] public PackedScene _exampleDefaultExportTruePackedScene;
+	[OnReadyGet("res://tex.png", OrNull = true, Export = true)] public PackedScene _exampleDefaultOrNullExportTruePackedScene;
 
 	[OnReady(Order = -5)] public void OrderMinus5DefinedEarly() { }
 }

--- a/godot/GodotOnReadyDev.csproj
+++ b/godot/GodotOnReadyDev.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/3.2.3">
+<Project Sdk="Godot.NET.Sdk/3.3.0">
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>

--- a/godot/Gui.tscn
+++ b/godot/Gui.tscn
@@ -53,5 +53,6 @@ margin_bottom = 20.0
 text = "Spawn"
 script = ExtResource( 3 )
 OtherPath = NodePath("../../HBoxContainer")
+
 [connection signal="pressed" from="HBoxContainer/Button" to="HBoxContainer/Button" method="OnPress"]
 [connection signal="pressed" from="HBoxContainer2/Button" to="HBoxContainer2/Button" method="OnPress"]

--- a/godot/SpawnButton.cs
+++ b/godot/SpawnButton.cs
@@ -3,7 +3,7 @@ using GodotOnReady.Attributes;
 
 public partial class SpawnButton : Button
 {
-	[OnReadyGet("res://Subgui.tscn", Private = true)] public PackedScene _scene;
+	[OnReadyGet("res://Subgui.tscn")] public PackedScene _scene;
 
 	public virtual void OnPress()
 	{

--- a/src/GodotOnReady.Attributes/Attributes.cs
+++ b/src/GodotOnReady.Attributes/Attributes.cs
@@ -13,7 +13,13 @@ namespace GodotOnReady.Attributes
 	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
 	public sealed class OnReadyGetAttribute : Attribute
 	{
-		public string Default { get; }
+		public string Path { get; }
+
+		/// <summary>
+		/// If true, always generates a property with [Export], even if Path isn't set. The exported
+		/// property can be used in the editor to change the Path.
+		/// </summary>
+		public bool Export { get; set; }
 
 		/// <summary>
 		/// Allows nulls and unexpected node types in the ready method without throwing exceptions.
@@ -21,21 +27,13 @@ namespace GodotOnReady.Attributes
 		/// </summary>
 		public bool OrNull { get; set; }
 
-		/// <summary>
-		/// Prevents exporting a generated property. This disables configuration from the Godot
-		/// scene. This can be used to hide properties that should not be configurable, while
-		/// continuing to automatically set the value in the generated ready method.
-		/// </summary>
-		public bool Private { get; set; }
-
-		/// <param name="default">
-		/// The default initialization path that will be loaded when the node is ready unless
-		/// configured otherwise in the Godot editor. The reset button in the Godot editor restores
-		/// this value.
+		/// <param name="path">
+		/// The path that will be loaded when the node is ready. If not set, a property is generated
+		/// with [Export], so the path can be set in the Godot editor.
 		/// </param>
-		public OnReadyGetAttribute(string @default = "")
+		public OnReadyGetAttribute(string path = "")
 		{
-			Default = @default;
+			Path = path;
 		}
 	}
 

--- a/src/GodotOnReady.Generator/Additions/DataSelectorEnumAddition.cs
+++ b/src/GodotOnReady.Generator/Additions/DataSelectorEnumAddition.cs
@@ -1,5 +1,4 @@
-﻿using GodotOnReady.Generator.Util;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using System;
 
 namespace GodotOnReady.Generator.Additions

--- a/src/GodotOnReady.Generator/Additions/OnReadyGetAddition.cs
+++ b/src/GodotOnReady.Generator/Additions/OnReadyGetAddition.cs
@@ -10,9 +10,9 @@
 		/// </summary>
 		public string SuffixlessExportPropertyName { get; }
 
-		public string? Default { get; }
+		public string? Path { get; }
+		public bool Export { get; }
 		public bool OrNull { get; }
-		public bool Private { get; }
 
 		public OnReadyGetAddition(MemberAttributeSite memberSite)
 			: base(memberSite.AttributeSite.Class)
@@ -29,9 +29,9 @@
 
 			foreach (var constructorArg in memberSite.AttributeSite.Attribute.ConstructorArguments)
 			{
-				if (constructorArg.Value is string @default)
+				if (constructorArg.Value is string path)
 				{
-					Default = @default;
+					Path = path;
 				}
 			}
 
@@ -39,14 +39,14 @@
 			{
 				switch (namedArg.Key)
 				{
-					case "Default" when namedArg.Value.Value is string s:
-						Default = s;
+					case "Path" when namedArg.Value.Value is string s:
+						Path = s;
+						break;
+					case "Export" when namedArg.Value.Value is bool b:
+						Export = b;
 						break;
 					case "OrNull" when namedArg.Value.Value is bool b:
 						OrNull = b;
-						break;
-					case "Private" when namedArg.Value.Value is bool b:
-						Private = b;
 						break;
 				}
 			}

--- a/src/GodotOnReady.Generator/Additions/OnReadyGetNodeAddition.cs
+++ b/src/GodotOnReady.Generator/Additions/OnReadyGetNodeAddition.cs
@@ -10,16 +10,18 @@ namespace GodotOnReady.Generator.Additions
 
 		public override Action<SourceStringBuilder>? DeclarationWriter => g =>
 		{
-			string export = Private ? "" : "[Export] ";
+			string export = Path is { Length: >0 } || Export
+				? "[Export] "
+				: "";
 
 			g.Line();
 			g.Line(export, "public NodePath ", ExportPropertyName, " { get; set; }");
 
-			if (Default is { Length: >0 })
+			if (Path is { Length: >0 })
 			{
 				g.BlockTab(() =>
 				{
-					g.Line("= ", SyntaxFactory.Literal(Default).ToString(), ";");
+					g.Line("= ", SyntaxFactory.Literal(Path).ToString(), ";");
 				});
 			}
 		};

--- a/src/GodotOnReady.Generator/Additions/OnReadyGetResourceAddition.cs
+++ b/src/GodotOnReady.Generator/Additions/OnReadyGetResourceAddition.cs
@@ -8,11 +8,13 @@ namespace GodotOnReady.Generator.Additions
 	{
 		public OnReadyGetResourceAddition(MemberAttributeSite site) : base(site) { }
 
-		private bool IsGeneratingAssignment => Default is { Length: >0 };
+		private bool IsGeneratingAssignment => Path is { Length: >0 };
 
 		public override Action<SourceStringBuilder>? DeclarationWriter => g =>
 		{
-			string export = Private ? "" : "[Export] ";
+			string export = Path is { Length: >0 } || Export
+				? "[Export] "
+				: "";
 
 			g.Line();
 			g.Line(export, "public ", Member.Type.ToFullDisplayString(), " ", ExportPropertyName);
@@ -63,7 +65,7 @@ namespace GodotOnReady.Generator.Additions
 		{
 			g.Line(Member.Name, " = GD.Load",
 				"<", Member.Type.ToFullDisplayString(), ">",
-				"(", SyntaxFactory.Literal(Default ?? "").ToString(), ");");
+				"(", SyntaxFactory.Literal(Path ?? "").ToString(), ");");
 		}
 
 		protected virtual string ExportPropertyName => SuffixlessExportPropertyName + "Resource";

--- a/src/GodotOnReady.Generator/GodotOnReadySourceGenerator.cs
+++ b/src/GodotOnReady.Generator/GodotOnReadySourceGenerator.cs
@@ -12,11 +12,11 @@ namespace GodotOnReady.Generator
 {
 	public record AttributeSite(
 		INamedTypeSymbol Class,
-		AttributeData Attribute) { }
+		AttributeData Attribute);
 
 	public record MemberAttributeSite(
 		MemberSymbol Member,
-		AttributeSite AttributeSite) { }
+		AttributeSite AttributeSite);
 
 	[Generator]
 	public class GodotOnReadySourceGenerator : ISourceGenerator


### PR DESCRIPTION
Right now, API length order goes like this:
* `[Export]` means the path must be specified in the scene.
* `[Export("Foo")]` means use a default path and let scenes tweak it.
* `[Export("Foo", Private=true)]` means use a specific path that it doesn't make sense to tweak.

The third case is much more normal than the second, so 2 and 3 should be swapped. This PR basically changes private to be true by default, but switches the name over to `Export=true` to be positive.