### PR TITLE
Allow OnReadyGet for "T : class"

### DIFF
--- a/godot/FetchByGeneric.cs
+++ b/godot/FetchByGeneric.cs
@@ -1,7 +1,17 @@
 ﻿using Godot;
 using GodotOnReady.Attributes;
 
-public partial class FetchByGeneric<T> : Node where T : Node
+public partial class FetchByGeneric<T> : Node where T : class
 {
 	[OnReadyGet] public T F { get; set; }
+}
+
+public partial class FetchByGenericLabel : FetchByGeneric<Label>
+{
+	[OnReady] private void TalkAboutIt() => GD.Print("Label text is:", F.Text);
+}
+
+public partial class FetchByGenericShout : FetchByGeneric<IShout>
+{
+	[OnReady] private void ShoutIt() => F.Shout();
 }

--- a/src/GodotOnReady.Generator/Util/RoslynExtensions.cs
+++ b/src/GodotOnReady.Generator/Util/RoslynExtensions.cs
@@ -54,10 +54,6 @@ namespace GodotOnReady.Generator.Util
 
 		public static bool IsInterface(this ITypeSymbol? type)
 		{
-			if (type is ITypeParameterSymbol p)
-			{
-				return p.ConstraintTypes.Any(ct => ct.TypeKind == TypeKind.Interface);
-			}
 			return type?.TypeKind == TypeKind.Interface;
 		}
 	}


### PR DESCRIPTION
Allow any `T` as long as it is (or implies) `where T : class`. Simplifies a little bit of the detection code and lets me be more sure the "hey, add `where T : class`" error is being emitted in the right conditions, so I changed it to be a bit more confident. 😄

* For https://github.com/31/GodotOnReady/issues/29