### PR TITLE
Add the `Property` -> GetNode implication back in to fix `[OnReadyGet("AnimationTree", Property = "parameters/playback")]`

### DIFF
--- a/godot/Gui.tscn
+++ b/godot/Gui.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://MyGui.cs" type="Script" id=1]
 [ext_resource path="res://SpawnButton.cs" type="Script" id=2]
@@ -7,6 +7,12 @@
 [ext_resource path="res://NodeImplementingIShout.cs" type="Script" id=5]
 [ext_resource path="res://FetchByGenericButton.cs" type="Script" id=6]
 [ext_resource path="res://FetchByGenericInterfaceConcrete.cs" type="Script" id=7]
+
+[sub_resource type="Gradient" id=1]
+
+[sub_resource type="GradientTexture" id=2]
+gradient = SubResource( 1 )
+width = 96
 
 [node name="Gui" type="VBoxContainer"]
 anchor_right = 1.0
@@ -87,6 +93,11 @@ FPath = NodePath("../HBoxContainer/Button")
 [node name="FetchByGenericInterface" type="Node" parent="."]
 script = ExtResource( 7 )
 FPath = NodePath("../ExampleShoutImplementer")
+
+[node name="GradientSprite" type="Sprite" parent="."]
+position = Vector2( 589, 54 )
+scale = Vector2( 1, 32 )
+texture = SubResource( 2 )
 
 [connection signal="pressed" from="HBoxContainer/Button" to="HBoxContainer/Button" method="OnPress"]
 [connection signal="pressed" from="HBoxContainer2/Button" to="HBoxContainer2/Button" method="OnPress"]

--- a/godot/MyGui.cs
+++ b/godot/MyGui.cs
@@ -24,6 +24,9 @@ public partial class MyGui : VBoxContainer
 
 	// [OnReadyGet("a/b/c")] private Button _notFoundNode;
 	// [OnReadyGet("a/b/d")] private Texture _notFoundResource;
+	
+	[OnReadyGet("GradientSprite", Property = "texture")] private GradientTexture _gt;
+	[OnReady] private void InitGradientEnd() => _gt.Gradient.SetColor(1, Colors.Blue);
 
 	[OnReady]
 	public void InitializeInput()

--- a/src/GodotOnReady.Attributes/Attributes.cs
+++ b/src/GodotOnReady.Attributes/Attributes.cs
@@ -29,6 +29,7 @@ namespace GodotOnReady.Attributes
 
 		/// <summary>
 		/// If set, the given property of the node will be injected instead of the node itself.
+		/// Path will also always be treated as a Node path, not a Resource path.
 		/// </summary>
 		public string Property { get; set; }
 

--- a/src/GodotOnReady.Generator/GodotOnReadySourceGenerator.cs
+++ b/src/GodotOnReady.Generator/GodotOnReadySourceGenerator.cs
@@ -120,6 +120,14 @@ namespace GodotOnReady.Generator
 							{
 								additions.Add(new OnReadyGetNodeAddition(site));
 							}
+							else if (site.AttributeSite.Attribute.NamedArguments
+								.Any(a => a.Key == "Property" && a.Value.Value is string { Length: > 0 }))
+							{
+								// If a Property path is given, always treat it as a node. The
+								// primary use of Property is to get a Resource from a Node that
+								// doesn't have a statically-typed .NET API.
+								additions.Add(new OnReadyGetNodeAddition(site));
+							}
 							else if (member.Type.IsOfBaseType(resourceSymbol))
 							{
 								additions.Add(new OnReadyGetResourceAddition(site));


### PR DESCRIPTION
I removed the `site.AttributeSite.Attribute.NamedArguments.Any(a => a.Key == "Property" && a.Value.Value is string { Length: > 0 })` check while working on this PR:

* https://github.com/31/GodotOnReady/pull/39
* https://github.com/31/GodotOnReady/pull/39/files?diff=unified&w=1#diff-7a5d5c8fc299baadded49003d04c49f1c5c50ed8bcbe19b024e5f9e9848a5582L114-L115

This causes the example in the readme (getting the animation state) not to work:

* https://github.com/31/GodotOnReady/issues/42

This PR adds the condition back in, and adds `Property` usage into the dev project so it'll be harder to overlook again. 🙂 

(I think that really, I should have had `[OnReadyGet]` and `[OnReadyLoad]` separated from the beginning. I don't think it's really all that useful to use the same attribute name for both Nodes and Resources. If you're switching a field/property from Node to a Resource, that's a big change--surely it's ok to change this, too. The library can even generate a very specific, clear compile error to make it easy.)